### PR TITLE
Fix incorrect stat reporting

### DIFF
--- a/ConnectionStats.h
+++ b/ConnectionStats.h
@@ -200,8 +200,8 @@ class ConnectionStats {
     }
 
     printf("%-7s %7.1f %7.1f %7.1f %7.1f %7.1f %7.1f %7.1f %7.1f",
-           tag, sampler.average(), sampler.stddev(),
-           sampler.get_nth(0), /*sampler.get_nth(1),*/ sampler.get_nth(5),
+           tag, sampler.average(), 
+           sampler.get_nth(0), sampler.get_nth(1), sampler.get_nth(5),
            sampler.get_nth(10), sampler.get_nth(90),
            sampler.get_nth(95), sampler.get_nth(99));
 


### PR DESCRIPTION
With the default Logger, mutilate was reporting the stddev as the
minimum and the minimum as the 1st percentile.
